### PR TITLE
Add misc libp2p methods

### DIFF
--- a/types/libp2p-bootstrap/index.d.ts
+++ b/types/libp2p-bootstrap/index.d.ts
@@ -18,7 +18,7 @@ declare namespace LibP2pBootstrap {
 declare class LibP2pBootstrap {
   constructor (options: LibP2pBootstrap.Options);
 
-  on (event: LibP2pBootstrap.Events, cb: (peerInfo: PeerInfo) => any): void;
+  on (event: LibP2pBootstrap.Events, cb: (peerInfo: PeerInfo) => any): this;
 }
 
 declare module 'libp2p-bootstrap' {

--- a/types/libp2p-mdns/index.d.ts
+++ b/types/libp2p-mdns/index.d.ts
@@ -21,7 +21,7 @@ declare namespace LibP2pMdns {
 declare class LibP2pMdns extends LibP2pBootstrap {
   constructor (options: LibP2pMdns.Options);
 
-  on (event: LibP2pMdns.Events, cb: (peerInfo: PeerInfo) => any): void;
+  on (event: LibP2pMdns.Events, cb: (peerInfo: PeerInfo) => any): this;
 }
 
 declare module 'libp2p-mdns' {

--- a/types/libp2p/index.d.ts
+++ b/types/libp2p/index.d.ts
@@ -25,6 +25,11 @@ declare namespace LibP2p {
             dht?: boolean
         },
         peerDiscovery?: {
+            bootstrap?: {
+                interval?: number
+                enabled?: boolean
+                list: Multiaddr.Multiaddr[]
+            },
             mdns?: {
                 interval?: number
                 enabled?: boolean
@@ -49,10 +54,10 @@ declare namespace LibP2p {
     };
 
     export type OptionsModules = {
-        connEncryption: Array<LibP2pSecio>,
+        connEncryption?: Array<LibP2pSecio>,
         streamMuxer: Array<LibP2pMplex | LibP2pSpdy | PullMplex>,
         dht?: typeof LibP2pKadDht,
-        peerDiscovery: Array<LibP2pBootstrap>,
+        peerDiscovery: Array<typeof LibP2pBootstrap>,
         transport: LibP2pTransport[]
     };
 
@@ -72,12 +77,17 @@ declare class LibP2p {
     constructor(options: LibP2p.Options);
 
     readonly peerInfo: PeerInfo;
+    readonly peerBook: PeerBook;
 
     dial(peerInfo: PeerInfo, cb: (error: Error | null) => any): void;
     dialProtocol(peerInfo: PeerInfo | Multiaddr.Multiaddr, protocol: string, cb: (error: Error | null, conn?: LibP2pConnection) => any): void;
+    hangUp(peerInfo: PeerInfo, cb: (error: Error | null) => any): void;
     handle(protocol: string, handler: (protocol: string, conn: LibP2pConnection) => any, matcher?: (protocol: string, requestedProtocol: string, cb: (error: Error | null, accept: boolean) => void) => any): void;
+    unhandle(protocol: string): void;
     isStarted(): boolean;
-    on(event: LibP2p.Events, cb: (event: any) => any): void;
+    on(event: LibP2p.Events, cb: (event: any) => any): this;
+    once(event: LibP2p.Events, cb: (event: any) => any): this;
+    removeListener(event: LibP2p.Events, cb: (event: any) => any): this;
     ping(peerInfo: PeerInfo, callback: (error: Error | null, ping: any) => void): void;
     start(cb: (error: Error | null) => any): void;
     stop(cb: (error: Error | null) => any): void;

--- a/types/pull-pushable/index.d.ts
+++ b/types/pull-pushable/index.d.ts
@@ -8,6 +8,7 @@
 declare module 'pull-pushable' {
 export type Pushable = {
     push: (buffer: Buffer) => void
+    end: (end?: any) => void
 };
 
 export type PullPushable = (errorHandler?: (error: Error) => void) => Pushable;


### PR DESCRIPTION
Hi @jacogr 
We've been using this great collection of types for the various libp2p-related typings in our project [chainsafe/lodestar](https://github.com/chainsafe/lodestar).

This is a minimal change for our current usage, so as we see additional room for improvement we will try to push the improvements back upstream here.

Most relate to the libp2p classes extending `EventEmitter`. I messed around with trying to actually `extend` EventEmitter in the declarations, but I'm not super familiar with the intricacies of typescript declarations, and for various reasons, couldn't get it to work.